### PR TITLE
Implement bottom up merge sort and test class

### DIFF
--- a/src/bottom_up_merge.py
+++ b/src/bottom_up_merge.py
@@ -1,0 +1,16 @@
+from src.sorter import Sorter
+
+
+class BottomUpMerge(Sorter):
+
+    def sort(self, values: list):
+        n = len(values)
+        aux = []
+        i = 1
+        # Using a while loop instead of the for loop recommended in the book because the new value of i is dependent on
+        # the previous value of i. for i in range(i, n, i) only uses the first value of i because the range is only
+        # evaluated once.
+        while i < n:
+            for j in range(0, n - i, 2 * i):
+                self.merge(values, j, j + i - 1, min(j + (2 * i) - 1, n - 1))
+            i = 2 * i

--- a/tests/test_bottom_up_merge.py
+++ b/tests/test_bottom_up_merge.py
@@ -1,0 +1,42 @@
+import unittest
+from src.input_generator import InputGenerator
+from src.bottom_up_merge import BottomUpMerge
+
+
+class TestTopDownMerge(unittest.TestCase):
+
+    def setUp(self):
+        test_input = InputGenerator()
+        self.int_data = test_input.make_random_number(100)
+        self.str_data = test_input.make_random_string(1000)
+        self.test = BottomUpMerge()
+
+    def test_selection_creation(self):
+        self.assertIsInstance(self.test, BottomUpMerge)
+
+    def test_int_sort(self):
+        int_test = []
+        for j in self.int_data:
+            int_test.append(j)
+        self.test.sort(int_test)
+        self.assertEqual(len(self.int_data), len(int_test))
+        for i in range(len(int_test)):
+            self.assertTrue(self.int_data[i] in int_test)
+        print(self.int_data)
+        print(int_test)
+        self.assertTrue(self.test.is_sorted(int_test))
+
+    def test_str_sort(self):
+        str_test = []
+        for k in self.str_data:
+            str_test.append(k)
+        self.test.sort(str_test)
+        self.assertEqual(len(self.str_data), len(str_test))
+        for i in range(len(str_test)):
+            self.assertTrue(self.str_data[i] in str_test)
+        print(self.str_data)
+        print(str_test)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Bottom up merge sort based upon the book example. Likely can be improved
by switching to insertion sort for subarrays with len(array) < 15.
Testing to see if subarray is already sorted before calling merge or
insertion sort.
Potentially can elimate the time taken to copy array to aux by
alternating the input and auxiliary array at each level by arranging the
recursive calls.

## Related issue (if applicable):

Implement bottom-up merge sort #2

Changes proposed in this pull request:
-Implement bottom-up merge sort.
-Implement test class for the BottomUpMerge class.

Capital of Assyria:
I don't know that!
AAAAAAAAAAAAHHHHHHHHHHHHHH
